### PR TITLE
Never define call_validation_error_handler twice

### DIFF
--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -10,9 +10,15 @@ module RSpec
       extend T::Helpers
 
       requires_ancestor { Kernel }
+      
+      class <<self
+        attr_accessor :defined
+      end
 
       sig { void }
       def allow_doubles!
+        return if RSpec::Sorbet::Doubles.defined
+        
         T::Configuration.inline_type_error_handler = proc do |error|
           inline_type_error_handler(error)
         end
@@ -25,6 +31,8 @@ module RSpec
         T::Configuration.call_validation_error_handler = proc do |signature, opts|
           call_validation_error_handler(signature, opts)
         end
+        
+        RSpec::Sorbet::Doubles.defined = true
       end
 
       alias_method :allow_instance_doubles!, :allow_doubles!


### PR DESCRIPTION
It results in a <SystemStackError: stack level too deep>.

I haven't figured out why this is occurring in one of our large code bases but somehow RSpec::Sorbet.allow_doubles! is being called again when Guard runs RSpec after the first time.

It results in this over and over until a SystemStackError is raised when a signature is incorrect:

```
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:17:in `block in allow_doubles!'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:32:in `handle_call_validation_error'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:120:in `call_validation_error_handler'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:17:in `block in allow_doubles!'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:32:in `handle_call_validation_error'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:120:in `call_validation_error_handler'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:17:in `block in allow_doubles!'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:32:in `handle_call_validation_error'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:120:in `call_validation_error_handler'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:17:in `block in allow_doubles!'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:32:in `handle_call_validation_error'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:120:in `call_validation_error_handler'
[GEM_PATH]/rspec-sorbet-1.9.1/lib/rspec/sorbet/doubles.rb:17:in `block in allow_doubles!'
```

I've tested this code out and it fixes the issue for us.