### PR TITLE
Add `.reset!` to prevent `SystemStackError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Rubocop offenses resolved
 - Sorbet signatures added to `RSpec::Sorbet::Doubles`
+- Added `RSpec::Sorbet.reset!` to restore handlers to previous state
+- Added fix to prevent `SystemStackError` by keeping track of when handlers have been configured. (thanks [@alex-tan](https://github.com/alex-tan))
+- Added logic to pass type error onwards to existing inline type error handler.
 
 ## 1.9.1
 

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -139,6 +139,20 @@ module RSpec
         it_behaves_like "it allows an instance double"
       end
 
+      describe "when called multiple times" do
+        before do
+          described_class.allow_doubles!
+          described_class.allow_doubles!
+        end
+
+        include_context "with instance doubles"
+
+        specify do
+          expect { Greeter.new(123) }.to(raise_error(TypeError))
+          expect { Greeter.new(my_person_double).greet }.not_to(raise_error)
+        end
+      end
+
       describe "with an existing error handler" do
         let(:handler) { proc { |_, _| raise ArgumentError, "foo" } }
 

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -120,8 +120,7 @@ module RSpec
     end
 
     after do
-      T::Configuration.inline_type_error_handler = nil
-      T::Configuration.call_validation_error_handler = nil
+      described_class.reset!(clear_existing: true)
     end
 
     describe ".allow_instance_doubles!" do
@@ -153,10 +152,27 @@ module RSpec
         end
       end
 
-      describe "with an existing error handler" do
+      describe "with an existing inline type error handler" do
+        let(:handler) { proc { |_| raise ArgumentError, "foo" } }
+
+        before do
+          described_class.reset!(clear_existing: true)
+          T::Configuration.inline_type_error_handler = handler
+          described_class.allow_doubles!
+        end
+
+        include_context "with instance doubles"
+
+        specify do
+          expect { Greeter.new(my_person_double).greet }.to(raise_error(ArgumentError, "foo"))
+        end
+      end
+
+      describe "with an existing call validation error handler" do
         let(:handler) { proc { |_, _| raise ArgumentError, "foo" } }
 
         before do
+          described_class.reset!(clear_existing: true)
           T::Configuration.call_validation_error_handler = handler
           described_class.allow_doubles!
         end


### PR DESCRIPTION
@alex-tan found that when calling `allow_doubles!` many times you can end up with `SystemStackError`'s being raised within the call validation handler.

This PR takes https://github.com/samuelgiles/rspec-sorbet/pull/26 and wraps it up in a more general `reset!` mechanism that is both available publicly (primarily for use in tests) and internally where a new `configured` variable is used to keep track of whether the inline + call handlers have been added.

The PR also adds support for passing type errors onwards to existing inline type error handlers.